### PR TITLE
Fix "disentanglement" of falling QBlocks

### DIFF
--- a/src/main/java/dan200/qcraft/shared/TileEntityQBlock.java
+++ b/src/main/java/dan200/qcraft/shared/TileEntityQBlock.java
@@ -600,6 +600,7 @@ public class TileEntityQBlock extends TileEntity
             m_sideBlockTypes[ i ] = nbttagcompound.getInteger( "s" + i );
             m_forceObserved[ i ] = nbttagcompound.getBoolean( "c" + i );
         }
+        validate();
     }
 
     @Override


### PR DESCRIPTION
If one or multiple instances of an entangled QBlock group change into a gravity dependent block like sand or gravel and if they are hanging in the air, they will temporarily change into falling blocks. When they re-materialize into solid blocks, they do not re-register in the Entanglement Registry and therefore become "disentangled". Adding this validate(); should fix that behaviour.