### PR TITLE
Revert "Fix "disentanglement" of falling QBlocks"

### DIFF
--- a/src/main/java/dan200/qcraft/shared/TileEntityQBlock.java
+++ b/src/main/java/dan200/qcraft/shared/TileEntityQBlock.java
@@ -600,7 +600,6 @@ public class TileEntityQBlock extends TileEntity
             m_sideBlockTypes[ i ] = nbttagcompound.getInteger( "s" + i );
             m_forceObserved[ i ] = nbttagcompound.getBoolean( "c" + i );
         }
-        validate();
     }
 
     @Override


### PR DESCRIPTION
Unfortunately the pull request TeacherGaming/qcraft-mod#5 does not solve the issue of disentangled quantum blocks. It also adds issue #6: a server restart 'breaks' entangled quantum blocks, making them only resolve to air.

I suggest we revert this commit and create a new issue for the 'disentanglement' bug.

Here are the steps to reproduce the 'disentanglement' bug:

1. Create a new creative mode world in single player.
2. Grab 4 blocks of a non-gravity-influenced block (stone), 4 blocks of a gravity-influenced block (sand), two Essence of Superposition, and one Essence of Entanglement.
3. Create two quantum blocks using the above ingredients, then use the Essence of Entanglement to entangle them.
4. Place a few of the entangled quantum blocks on the ground.
5. Using some block, build directly up next to your entangled quantum blocks until you are at a very high height.
6. Add an entangled quantum block at the top.
7. Make sure it is resolved to a non-gravity-influenced block and put on your Anti-Observation Goggles.
8. Remove all blocks that are below your high entangled quantum block.
9. Remove your Anti-Observation Goggles and resolve the entangled quantum blocks on the ground to a gravity-influenced block, then QUICKLY resolve them to a non-gravity-influenced block before the high entangled quantum block hits the ground.
10. Notice how the once high entangled quantum block remains a gravity-influenced block, even after hitting the ground.
11. When you resolve the blocks another time, everything returns to normal.

It is also possible to refrain from fixing this 'bug' and keeping it on as a feature, however that is a topic for another discussion.